### PR TITLE
BalanceOf Impementation

### DIFF
--- a/contracts/ERC721/ERC721.sol
+++ b/contracts/ERC721/ERC721.sol
@@ -240,6 +240,9 @@ contract ERC721 is
         if (!hasWritten){
             return parent.balanceOf(_owner) + localBalance;
         }
+        else if (!hasWritten){
+            return parent.balanceOf(_owner);
+        }
         return localBalance;
     }
     /**

--- a/contracts/ERC721/ERC721.sol
+++ b/contracts/ERC721/ERC721.sol
@@ -237,11 +237,8 @@ contract ERC721 is
         uint256 localBalance = _balances[_owner];
         bool hasWritten = _hasWritten[_owner];
         
-        if (localBalance > 0 && !hasWritten){
+        if (!hasWritten){
             return parent.balanceOf(_owner) + localBalance;
-        }
-        else if (!hasWritten){
-            return parent.balanceOf(_owner);
         }
         return localBalance;
     }


### PR DESCRIPTION
### Implementation Details
 - Added _balances and _hasWritten mappings, address => uint256 & address => bool, respectively 
 - **transferFrom(from, to, id)**. If it is the caller's first transfer ever, we set their balance to be the parent's balance + the balance in local storage - 1. Where the -1 represents the token that is moved **from** to **to**. 
 - **balanceOf(_owner)**, if _haswritten[_owner] is false, aka. has never transferred any token, we know that their balance in local storage has never been written to before by the _owner,  therefore we return parent.balanceOf(_owner) + _balances[_owner]  where _balances[owner] represents all the tokens that have been transferred to the owner by other addresses.  If _haswritter[_owner] is true, we just return the value in local storage **return _balances[_owner]**
 
 
### Trade-off
- gas used in TransferFrom is more on first-write, subsequent transfers are cheaper.